### PR TITLE
fix(weibo): 移除默认的微博API基础URL

### DIFF
--- a/src/lib/weibo/inject/install-api-bridge.ts
+++ b/src/lib/weibo/inject/install-api-bridge.ts
@@ -8,7 +8,7 @@ import {
 } from '@/lib/weibo/platform/messages'
 
 const DEFAULT_TIMEOUT_MS = 10000
-const WEIBO_API_BASE = 'https://weibo.com'
+const WEIBO_API_BASE = ''
 
 function readXsrfTokenFromCookie(): string | null {
   const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/)

--- a/src/lib/weibo/inject/install-api-bridge.ts
+++ b/src/lib/weibo/inject/install-api-bridge.ts
@@ -8,7 +8,19 @@ import {
 } from '@/lib/weibo/platform/messages'
 
 const DEFAULT_TIMEOUT_MS = 10000
-const WEIBO_API_BASE = ''
+
+function getWeiboApiBase(): string {
+  if (import.meta.env.FIREFOX) {
+    const host = window.location.host
+    if (host === 'weibo.com' || host === 'www.weibo.com') {
+      return `https://${host}`
+    }
+    return 'https://weibo.com'
+  }
+  return ''
+}
+
+const WEIBO_API_BASE = getWeiboApiBase()
 
 function readXsrfTokenFromCookie(): string | null {
   const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/)


### PR DESCRIPTION
在使用www.weibo.com访问微博时，会导致跨域问题使得无法通过api获取信息，移除硬编码
<img width="1830" height="984" alt="image" src="https://github.com/user-attachments/assets/ea8785c6-62d6-402c-822e-f99c37dad981" />
<img width="1127" height="637" alt="image" src="https://github.com/user-attachments/assets/c0c6be8b-482c-4480-8a76-ae47fb8dd519" />
